### PR TITLE
GET oidc_func_clientauth.html gir HTTP 404

### DIFF
--- a/_data/sidebars/oidc.yml
+++ b/_data/sidebars/oidc.yml
@@ -68,9 +68,9 @@ entries:
         url: /oidc_func_sso.html
         output: web, pdf
 
-      - title: Klientautentisering
-        url: /oidc_func_clientauth.html
-        output: web, pdf
+#     - title: Klientautentisering
+#       url: /oidc_func_clientauth.html
+#       output: web, pdf
 
       - title: Klientregistrering
         url: /oidc_func_clientreg.html


### PR DESCRIPTION
Hei. Takk for fine dokumentasjonssider!
Det er feil i en link til en side, jeg har bare kommentert ut linken til den, kanskje dere har renavnet den aktuelle siden.
Vennlig hilsen Jan Helge